### PR TITLE
Execute color

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -139,6 +139,10 @@ local function nameplateUpdateHealth(self, event, unit)
 
 	local healthbar = self.Health
 	local cur, max = UnitHealth(unit), UnitHealthMax(unit)
+	local perc = 100;
+	if (cur ~= 0) then
+		perc = cur / max * 100
+	end
 	healthbar:SetMinMaxValues(0, max)
 	healthbar:SetValue(cur)
 
@@ -146,11 +150,12 @@ local function nameplateUpdateHealth(self, event, unit)
 	local isPlayer = UnitIsPlayer(unit) and select(2, UnitClass(unit)) or false
 	local reaction = UnitReaction("player", unit) or false
 	local status = UnitThreatSituation("player", unit)
+	local executable = perc <= config.executerange
 	if (status == nil) then
 		status = false
 	end
 
-	local colors = bdNameplates:unitColor(tapDenied, isPlayer, reaction, status)
+	local colors = bdNameplates:unitColor(tapDenied, isPlayer, reaction, status, executable)
 	healthbar:SetStatusBarColor(unpack(colors))
 
 -- 	function bdNameplates:unitColor(unit)

--- a/functions.lua
+++ b/functions.lua
@@ -29,15 +29,14 @@ local function colorSave(self, tapDenied, isPlayer, reaction, status, executable
 -- 		self.Health:SetStatusBarColor(bdNameplates:unitColor(unit))
 -- 	elseif (status ~= nil and not UnitIsTapDenied(unit) and not UnitIsPlayer(unit) and (event == "UNIT_THREAT_LIST_UPDATE" or event == "NAME_PLATE_UNIT_ADDED")) then
 
-	if (isPlayer or status == false) then
-		if isPlayer then
-			return colors.class[isPlayer]
-		elseif (tapDenied) then
+	if (isPlayer) then
+		return colors.class[isPlayer]
+	elseif (config.executecoloring and executable and not tapDenied) then
+		return config.executecolor
+	elseif (status == false) then
+		if (tapDenied) then
 			return colors.tapped
 		else
-			if (config.executecoloring and executable) then
-				return config.executecolor
-			end
 			return colors.reaction[reaction]
 		end
 	else

--- a/functions.lua
+++ b/functions.lua
@@ -29,16 +29,14 @@ local function colorSave(self, tapDenied, isPlayer, reaction, status, executable
 -- 		self.Health:SetStatusBarColor(bdNameplates:unitColor(unit))
 -- 	elseif (status ~= nil and not UnitIsTapDenied(unit) and not UnitIsPlayer(unit) and (event == "UNIT_THREAT_LIST_UPDATE" or event == "NAME_PLATE_UNIT_ADDED")) then
 
-	if (isPlayer) then
+	if (tapDenied) then
+		return colors.tapped
+	elseif (isPlayer) then
 		return colors.class[isPlayer]
 	elseif (config.executecoloring and executable and not tapDenied) then
 		return config.executecolor
 	elseif (status == false) then
-		if (tapDenied) then
-			return colors.tapped
-		else
-			return colors.reaction[reaction]
-		end
+		return colors.reaction[reaction]
 	else
 		if (status == 3) then
 			-- securely tanking

--- a/functions.lua
+++ b/functions.lua
@@ -24,7 +24,7 @@ for eclass, color in next, FACTION_BAR_COLORS do
 	end
 end
 
-local function colorSave(self, tapDenied, isPlayer, reaction, status)
+local function colorSave(self, tapDenied, isPlayer, reaction, status, executable)
 	-- if (unit == 'player' or UnitIsUnit('player', unit) or UnitIsFriend('player', unit) or status == nil) then
 -- 		self.Health:SetStatusBarColor(bdNameplates:unitColor(unit))
 -- 	elseif (status ~= nil and not UnitIsTapDenied(unit) and not UnitIsPlayer(unit) and (event == "UNIT_THREAT_LIST_UPDATE" or event == "NAME_PLATE_UNIT_ADDED")) then
@@ -35,6 +35,9 @@ local function colorSave(self, tapDenied, isPlayer, reaction, status)
 		elseif (tapDenied) then
 			return colors.tapped
 		else
+			if (config.executecoloring and executable) then
+				return config.executecolor
+			end
 			return colors.reaction[reaction]
 		end
 	else

--- a/init.lua
+++ b/init.lua
@@ -180,6 +180,12 @@ defaults[#defaults+1] = {hidecasticon = {
 	label = "Hide Castbar Icon",
 	callback = function() bdNameplates:configCallback() end
 }}
+defaults[#defaults+1] = {executecoloring = {
+	type = "checkbox",
+	value = false,
+	label = "Execute Range Color",
+	callback = function() bdNameplates:configCallback() end
+}}
 --[[
 defaults[#defaults+1] = {nameplatemotion = {
 	type = "dropdown",


### PR DESCRIPTION
Hello!

This PR colors nameplate healthbars when they fall beneath execute threshold, making use of existing code, and the memoized colorSave function.

It also adds a checkbox in the config for enabling the feature, but as-is the checkbox is partially cut off.  Increasing the height to 470 in bdCore looked good to me, but that's outside of this repo.